### PR TITLE
Feature/sha identification

### DIFF
--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -1,12 +1,15 @@
 # ----------------------------Compatibility Imports----------------------------
 from __future__ import print_function
 from six.moves import range
+
+import sys
+import hashlib
+if sys.version_info < (3, 6):
+    import sha3
 # -----------------------------------------------------------------------------
 
-import hashlib
 import os
 import hmac  # Python 2.7 and 3.3+
-
 
 # TODO: Implement hash method choices
 
@@ -57,7 +60,7 @@ class HashCheck(object):
 
     @staticmethod
     def compare_digests(digest_1, digest_2):
-        """Returns True if digest_1 == digest_2
+        """Returns result of equality comparison betwen digest_1 and digest_2
         
         Args:
             digest_1 (str): digest to be compared against digest_2
@@ -68,4 +71,5 @@ class HashCheck(object):
         """
 
         return hmac.compare_digest(digest_1, digest_2)
+
 

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -4,12 +4,14 @@ from six.moves import range
 
 import sys
 import hashlib
+
 if sys.version_info < (3, 6):
     import sha3
 # -----------------------------------------------------------------------------
 
 import os
 import hmac  # Python 2.7 and 3.3+
+
 
 # TODO: Implement hash method choices
 
@@ -25,7 +27,7 @@ class HashCheck(object):
             digest (str): filename or string containing digest to be processed
         
         Returns:
-            str: hash digest stipped of leading and trailing whitespace
+            str: hash digest stripped of leading and trailing whitespace
         """
 
         if os.path.isfile(digest):
@@ -60,7 +62,7 @@ class HashCheck(object):
 
     @staticmethod
     def compare_digests(digest_1, digest_2):
-        """Returns result of equality comparison betwen digest_1 and digest_2
+        """Returns result of equality comparison between digest_1 and digest_2
         
         Args:
             digest_1 (str): digest to be compared against digest_2
@@ -73,3 +75,28 @@ class HashCheck(object):
         return hmac.compare_digest(digest_1, digest_2)
 
 
+def determine_sha_method(digest, family='sha2'):
+    """Returns SHA method to be used for digest comparison
+    
+    Args:
+        digest (str): user provided hexdigest used to determine sha method
+        family (str, optional): determines sha2 vs sha3 usage
+    
+    Returns:
+        object: built in hashlib method built from sha_variants dictionary
+    """
+
+    sha_versions = {
+        'sha2': {56: 'sha224', 64: 'sha256', 96: 'sha384', 128: 'sha512'},
+        'sha3': {56: 'sha3_224', 64: 'sha3_256', 96: 'sha3_384', 128: 'sha3_512'}
+    }
+
+    variant = sha_versions[family][len(digest)]
+
+    return getattr(hashlib, variant)
+
+
+if __name__ == '__main__':
+    s = determine_sha_method(
+        'cda7a4ef4ff52524f06ebb8a3aea815f7df0dbcf27a7d501141f6f0fdf726ccd')
+    print(s)

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -20,7 +20,10 @@ import hmac  # Python 2.7 and 3.3+
 class Digest(object):
     """Class for comparing, processing, and generating hash digests."""
 
-    def determine_sha_method(digest, family):
+    def __init__(self, hash_family):
+        self.family = hash_family
+
+    def build_hash_object(self, digest):
         """Returns SHA method to be used for digest comparison
 
         Args:
@@ -31,12 +34,18 @@ class Digest(object):
             object: built in hashlib method built from sha_variants dictionary
         """
 
-        sha_versions = {
+        fixed_variants = {
             'sha2': {56: 'sha224', 64: 'sha256', 96: 'sha384', 128: 'sha512'},
             'sha3': {56: 'sha3_224', 64: 'sha3_256', 96: 'sha3_384', 128: 'sha3_512'}
         }
 
-        variant = sha_versions[family][len(digest)]
+        dynamic_variants = {
+            'shake': {'128': 'shake_128', '256': 'shake_256'},
+            'blake': {'2s': 'blake2s', '2b': 'blake2b'}
+        }
+
+        if self.family in fixed_variants:
+            variant = fixed_variants[self.family][len(digest)]
 
         return getattr(hashlib, variant)
 
@@ -101,4 +110,4 @@ def compare_digests(digest_1, digest_2):
 
 
 if __name__ == '__main__':
-    pass
+    print(hashlib.blake2b.__dict__.keys())

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -17,8 +17,29 @@ import hmac  # Python 2.7 and 3.3+
 # TODO: Implement SHAKE and BLAKE
 # TODO: Resist urge to call it "SHAKE'N BLAKE"
 
-class HashCheck(object):
+class Digest(object):
     """Class for comparing, processing, and generating hash digests."""
+
+    def determine_sha_method(digest, family):
+        """Returns SHA method to be used for digest comparison
+
+        Args:
+            digest (str): user provided hexdigest used to determine sha method
+            family (str, optional): determines sha2 vs sha3 usage
+
+        Returns:
+            object: built in hashlib method built from sha_variants dictionary
+        """
+
+        sha_versions = {
+            'sha2': {56: 'sha224', 64: 'sha256', 96: 'sha384', 128: 'sha512'},
+            'sha3': {56: 'sha3_224', 64: 'sha3_256', 96: 'sha3_384', 128: 'sha3_512'}
+        }
+
+        variant = sha_versions[family][len(digest)]
+
+        return getattr(hashlib, variant)
+
 
     @staticmethod
     def process_digest(digest):
@@ -62,40 +83,21 @@ class HashCheck(object):
 
         return hash_digest.hexdigest()
 
-    @staticmethod
-    def compare_digests(digest_1, digest_2):
-        """Returns result of equality comparison between digest_1 and digest_2
 
-        Args:
-            digest_1 (str): digest to be compared against digest_2
-            digest_2 (str): digest to be compared against digest_1
-
-        Returns:
-            bool: result of comparison of digest_1 and digest_2
-        """
-
-        return hmac.compare_digest(digest_1, digest_2)
-
-
-def determine_sha_method(digest, family):
-    """Returns SHA method to be used for digest comparison
+def compare_digests(digest_1, digest_2):
+    """Returns result of equality comparison between digest_1 and digest_2.  Included
 
     Args:
-        digest (str): user provided hexdigest used to determine sha method
-        family (str, optional): determines sha2 vs sha3 usage
+        digest_1 (str): digest to be compared against digest_2
+        digest_2 (str): digest to be compared against digest_1
 
     Returns:
-        object: built in hashlib method built from sha_variants dictionary
+        bool: result of comparison of digest_1 and digest_2
     """
 
-    sha_versions = {
-        'sha2': {56: 'sha224', 64: 'sha256', 96: 'sha384', 128: 'sha512'},
-        'sha3': {56: 'sha3_224', 64: 'sha3_256', 96: 'sha3_384', 128: 'sha3_512'}
-    }
+    return hmac.compare_digest(digest_1, digest_2)
 
-    variant = sha_versions[family][len(digest)]
 
-    return getattr(hashlib, variant)
 
 
 if __name__ == '__main__':

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -77,7 +77,7 @@ class HashCheck(object):
         return hmac.compare_digest(digest_1, digest_2)
 
 
-def determine_sha_method(digest, family='sha2'):
+def determine_sha_method(digest, family):
     """Returns SHA method to be used for digest comparison
 
     Args:

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -9,16 +9,21 @@ import hmac  # Python 2.7 and 3.3+
 
 
 # TODO: Implement hash method choices
-# TODO: Repent for not adding doc-strings, then add the doc-strings
 
 class HashCheck(object):
-    """Class for comparing, processing, and generating hash digests"""
+    """Class for comparing, processing, and generating hash digests."""
 
     @staticmethod
     def process_digest(digest):
-        """Either returns digest read from file, or returns digest with
-        leading/trailing whitespace stripped.  Process action based on digest
-        source."""
+        """Determines if source of digest is stored in a text file, or if it's a
+        string provided by user.
+        
+        Args:
+            digest (str): filename or string containing digest to be processed
+        
+        Returns:
+            str: hash digest stipped of leading and trailing whitespace
+        """
 
         if os.path.isfile(digest):
             with open(digest, 'r') as f:
@@ -28,7 +33,14 @@ class HashCheck(object):
 
     @staticmethod
     def generate_digest(filename):
-        """Returns hexadecimal digest generated from filename"""
+        """Returns hexadecimal digest generated from filename
+        
+        Args:
+            filename (str): filename of binary file
+        
+        Returns:
+            str: hash digest generated from binary file
+        """
 
         buffer_size = 65536  # Buffer used to cut down on memory for large files.
         blocks = (os.path.getsize(filename) // buffer_size) + 1
@@ -45,6 +57,15 @@ class HashCheck(object):
 
     @staticmethod
     def compare_digests(digest_1, digest_2):
-        """Returns True if digest_1 == digest_2"""
+        """Returns True if digest_1 == digest_2
+        
+        Args:
+            digest_1 (str): digest to be compared against digest_2
+            digest_2 (str): digest to be compared against digest_1
+        
+        Returns:
+            bool: result of comparison of digest_1 and digest_2
+        """
 
         return hmac.compare_digest(digest_1, digest_2)
+

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -6,6 +6,7 @@ import sys
 import hashlib
 
 if sys.version_info < (3, 6):
+    # noinspection PyUnresolvedReferences
     import sha3
 # -----------------------------------------------------------------------------
 
@@ -13,7 +14,8 @@ import os
 import hmac  # Python 2.7 and 3.3+
 
 
-# TODO: Implement hash method choices
+# TODO: Implement SHAKE and BLAKE
+# TODO: Resist urge to call it "SHAKE'N BLAKE"
 
 class HashCheck(object):
     """Class for comparing, processing, and generating hash digests."""
@@ -22,10 +24,10 @@ class HashCheck(object):
     def process_digest(digest):
         """Determines if source of digest is stored in a text file, or if it's a
         string provided by user.
-        
+
         Args:
             digest (str): filename or string containing digest to be processed
-        
+
         Returns:
             str: hash digest stripped of leading and trailing whitespace
         """
@@ -39,10 +41,10 @@ class HashCheck(object):
     @staticmethod
     def generate_digest(filename):
         """Returns hexadecimal digest generated from filename
-        
+
         Args:
             filename (str): filename of binary file
-        
+
         Returns:
             str: hash digest generated from binary file
         """
@@ -63,11 +65,11 @@ class HashCheck(object):
     @staticmethod
     def compare_digests(digest_1, digest_2):
         """Returns result of equality comparison between digest_1 and digest_2
-        
+
         Args:
             digest_1 (str): digest to be compared against digest_2
             digest_2 (str): digest to be compared against digest_1
-        
+
         Returns:
             bool: result of comparison of digest_1 and digest_2
         """
@@ -77,11 +79,11 @@ class HashCheck(object):
 
 def determine_sha_method(digest, family='sha2'):
     """Returns SHA method to be used for digest comparison
-    
+
     Args:
         digest (str): user provided hexdigest used to determine sha method
         family (str, optional): determines sha2 vs sha3 usage
-    
+
     Returns:
         object: built in hashlib method built from sha_variants dictionary
     """

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -97,6 +97,4 @@ def determine_sha_method(digest, family='sha2'):
 
 
 if __name__ == '__main__':
-    s = determine_sha_method(
-        'cda7a4ef4ff52524f06ebb8a3aea815f7df0dbcf27a7d501141f6f0fdf726ccd')
-    print(s)
+    pass

--- a/src/hash_check/hashchk_terminal.py
+++ b/src/hash_check/hashchk_terminal.py
@@ -8,6 +8,8 @@ import hashchk
 
 """Classes and functions for hashchk terminal use"""
 
+#TODO: Figure out what to do about sha3 argument under common groups
+
 
 class HashChkParser(object):
     """Class for creating and assembling argparse object used in hashchk.py"""
@@ -16,78 +18,82 @@ class HashChkParser(object):
         self.parser = self.create_parser()
         self.subparser = self.create_subparser()
 
-        self.add_subparser_parsers()
+        self.add_verify_subparser()
 
-    @staticmethod
-    def create_parser():
+
+    def create_parser(self):
         """Returns main parser object used for all argparse arguments"""
 
         return argparse.ArgumentParser(
             description="Generate and compare hash digests")
 
+
     def create_subparser(self):
         """returns main subparser derived from self.parser"""
 
-        return self.parser.add_subparsers(title="Commands",
-                                          description="Available Actions")
+        return self.parser.add_subparsers(
+            title="Commands", description="Available Actions")
 
-    def add_subparser_parsers(self):
-        """Calls methods responsible for adding parsers to main subparser"""
-
-        self.add_verify_subparser()
 
     def add_verify_subparser(self):
         """Creates the 'verify' subparser and adds related arguments"""
 
         verify_parser = self.subparser.add_parser(
             'verify',
-            help="Generate a hash digest from a binary and compare it against \
+            help="""Generate a hash digest from a binary and compare it against \
             a provided digest. Hash method defaults to SHA-2 if algorithm \
-            family not specified by user")
+            family not specified by user""")
 
-        #Required paramaters group
+        #Required parameters group
         req_group = verify_parser.add_argument_group('Required Parameters')
         req_group.add_argument(
-            '-dig', '--digest', required=True, metavar="STRING|FILENAME",
-            help="Either a string or filename to a file containing a valid hash \
-            digest")
+            '-d', '--digest', required=True, metavar="STRING|FILENAME",
+            help="""Either a string or filename to a file containing a valid \
+            hash digest""")
 
         req_group.add_argument(
             '-bin', '--binary', dest='binary', required=True,
             metavar="FILENAME|PATH/FILENAME",
-            help="Generates a hash digest of of the file located at \
-            PATH/FILENAME, or just FILENAME if file is located in the cwd.")
+            help="""Generates a hash digest of of the file located at \
+            PATH/FILENAME, or just FILENAME if file is located in the cwd.""")
 
-        # Hash algorithm choices
-        opt_group = verify_parser.add_argument_group('Algorithm Parameters')
-        opt_group.add_argument(
+        self.add_common_groups(verify_parser)
+
+    @staticmethod
+    def add_common_groups(parent):
+        """Adds common groups to subparser object.  While argparse supports a
+        parent option, it's a pain getting the groups in the right order after
+        the fact."""
+
+        algorithms_group = parent.add_argument_group('Algorithm Parameters')
+        algorithms_group.add_argument(
             '-sha3', dest='hash_family', action='store_true',
-            help="Use SHA-3 (fixed length) instead of SHA-2.  Bit length is \
-            determined automatically based on digest processed through -d switch")
+            help="""Use SHA-3 (fixed length) instead of SHA-2.""")
 
-        opt_group.add_argument(
+        algorithms_group.add_argument(
             '-shake128', dest='hash_family', nargs=1, metavar='LENGTH',
             help="Use SHA-3's SHAKE-128 with following LENGTH")
 
-        opt_group.add_argument(
+        algorithms_group.add_argument(
             '-shake256', dest='hash_family', nargs=1, metavar='LENGTH',
             help="Use SHA-3's SHAKE-256 with following LENGTH")
 
-        opt_group.add_argument(
+        algorithms_group.add_argument(
             '-blake2', dest='hash_family', nargs='+', metavar="s|b **kwargs",
-            help="Acts as a wrapper for python's hashlib.blake2s() and \
-            hashlib.blake2b() methods. The only required paramater is the \
+            help=""""Acts as a wrapper for python's hashlib.blake2s() and \
+            hashlib.blake2b() methods. The only required parameter is the \
             desired BLAKE2 version: s|b -- Although this switch can be \
             used as without any kwargs, default values can be overridden using \
             kwargs found in python3's documentation for BLAKE2s EXCEPT data, \
-            which is provided already through the -bin switch.")
+            which is provided already through the -bin switch.""")
 
-        opt_group.add_argument(
+        algorithms_group.add_argument(
             '--insecure', metavar='NAME', choices=['md5', 'sha1'],
             help="""WARNING: MD5 and SHA1 are insecure hash algorithms; they \
             should only be used to check for unintentional data corruption. \
             You can force use of one of these two methods by using this switch \
             along with the hash algorithm name.""")
+
 
     def get_parser_args(self):
         """Returns arguments parsed by main argparse object"""

--- a/src/hash_check/hashchk_terminal.py
+++ b/src/hash_check/hashchk_terminal.py
@@ -4,8 +4,7 @@ import os
 import sys
 import argparse
 import colorama
-
-from hashchk import HashCheck
+import hashchk
 
 """Classes and functions for hashchk terminal use"""
 
@@ -103,22 +102,23 @@ class Output(object):
 
 
 def _compare_verify_digests(verify_args):
-    """Takes in parsed arguments from HashChkParserverify subparser and prints
+    """Takes in parsed arguments from HashChkParser verify subparser and prints
     out comparison results."""
 
     Output.print_comparison_startup()
+    digest = hashchk.Digest()
 
     # provided printout
-    provided_digest = HashCheck.process_digest(verify_args.digest)
+    provided_digest = digest.process_digest(verify_args.digest)
     print(" Provided :{}".format(provided_digest))
 
     # stdout used to provide status message while digest is being generated
     sys.stdout.write(' Generated: {}'.format('Calculating'.center(60)))
-    generated_digest = HashCheck.generate_digest(args.binary)
+    generated_digest = digest.generate_digest(args.binary)
     sys.stdout.write("\r Generated:{}\n".format(generated_digest))
 
     # Compare and printout results
-    result = HashCheck.compare_digests(provided_digest, generated_digest)
+    result = hashchk.compare_digests(provided_digest, generated_digest)
     Output.print_comparison_results(result)
 
 

--- a/src/hash_check/hashchk_terminal.py
+++ b/src/hash_check/hashchk_terminal.py
@@ -40,35 +40,54 @@ class HashChkParser(object):
         """Creates the 'verify' subparser and adds related arguments"""
 
         verify_parser = self.subparser.add_parser(
-            'verify', action='store_true',
+            'verify',
             help="Generate a hash digest from a binary and compare it against \
-            a provided SHA-digest")
+            a provided digest. Hash method defaults to SHA-2 if algorithm \
+            family not specified by user")
 
-        verify_parser.add_argument(
-            '-d', '--digest', required=True, metavar="STRING|FILENAME",
-            help="Either a string or filename to a file containing the SHA hash \
+        #Required paramaters group
+        req_group = verify_parser.add_argument_group('Required Parameters')
+        req_group.add_argument(
+            '-dig', '--digest', required=True, metavar="STRING|FILENAME",
+            help="Either a string or filename to a file containing a valid hash \
             digest")
 
-        verify_parser.add_argument(
-            '-bin', '--binary-file', dest='binary', required=True,
-            metavar="FILENAME",
-            help="Binary file to compare the provided SHA digest against")
+        req_group.add_argument(
+            '-bin', '--binary', dest='binary', required=True,
+            metavar="FILENAME|PATH/FILENAME",
+            help="Generates a hash digest of of the file located at \
+            PATH/FILENAME, or just FILENAME if file is located in the cwd.")
 
-        verify_parser.add_argument(
-            '-hf', '--hash-family', dest='hash_family', required=False,
-            metavar="NAME", choices=['sha2, sha3'], default='sha2',
-            help="The verify command defaults to SHA2 if the -hf switch isn't \
-            provided. You can use this switch along with the hash-family's \
-            name to override this default.  Specific hash functions within a \
-            family are automatically determined by the length of the digest \
-            provided to the -d switch.")
+        # Hash algorithm choices
+        opt_group = verify_parser.add_argument_group('Algorithm Parameters')
+        opt_group.add_argument(
+            '-sha3', dest='hash_family', action='store_true',
+            help="Use SHA-3 (fixed length) instead of SHA-2.  Bit length is \
+            determined automatically based on digest processed through -d switch")
 
-        verify_parser.add_argument(
-            '--insecure', metavar='HASH-ALGORITHM', choices=['md5', 'sha1'],
+        opt_group.add_argument(
+            '-shake128', dest='hash_family', nargs=1, metavar='LENGTH',
+            help="Use SHA-3's SHAKE-128 with following LENGTH")
+
+        opt_group.add_argument(
+            '-shake256', dest='hash_family', nargs=1, metavar='LENGTH',
+            help="Use SHA-3's SHAKE-256 with following LENGTH")
+
+        opt_group.add_argument(
+            '-blake2', dest='hash_family', nargs='+', metavar="s|b **kwargs",
+            help="Acts as a wrapper for python's hashlib.blake2s() and \
+            hashlib.blake2b() methods. The only required paramater is the \
+            desired BLAKE2 version: s|b -- Although this switch can be \
+            used as without any kwargs, default values can be overridden using \
+            kwargs found in python3's documentation for BLAKE2s EXCEPT data, \
+            which is provided already through the -bin switch.")
+
+        opt_group.add_argument(
+            '--insecure', metavar='NAME', choices=['md5', 'sha1'],
             help="""WARNING: MD5 and SHA1 are insecure hash algorithms; they \
-            should only be used to check for unintentional data corruption. If \
-            your options are limited to MD5 and/or SHA1, you can force \
-            comparison using this switch followed by the HA name.""")
+            should only be used to check for unintentional data corruption. \
+            You can force use of one of these two methods by using this switch \
+            along with the hash algorithm name.""")
 
     def get_parser_args(self):
         """Returns arguments parsed by main argparse object"""
@@ -126,4 +145,4 @@ if __name__ == '__main__':
     os.system('cls')
     colorama.init(convert=True)
     args = HashChkParser().get_parser_args()
-    _compare_verify_digests(args)
+    #_compare_verify_digests(args)

--- a/src/hash_check/hashchk_terminal.py
+++ b/src/hash_check/hashchk_terminal.py
@@ -47,7 +47,8 @@ class HashChkParser(object):
 
         verify_parser.add_argument(
             '-d', '--digest', required=True, metavar="STRING|FILENAME",
-            help="Either a string or filename containing the SHA-2 hash digest")
+            help="Either a string or filename to a file containing the SHA hash \
+            digest")
 
         verify_parser.add_argument(
             '-bin', '--binary-file', dest='binary', required=True,
@@ -55,7 +56,16 @@ class HashChkParser(object):
             help="Binary file to compare the provided SHA digest against")
 
         verify_parser.add_argument(
-            '--insecure', metavar='HASH-ALGORITHM', choices=['MD5', 'SHA1'],
+            '-hf', '--hash-family', dest='hash_family', required=False,
+            metavar="NAME", choices=['sha2, sha3'], default='sha2',
+            help="The verify command defaults to SHA2 if the -hf switch isn't \
+            provided. You can use this switch along with the hash-family's \
+            name to override this default.  Specific hash functions within a \
+            family are automatically determined by the length of the digest \
+            provided to the -d switch.")
+
+        verify_parser.add_argument(
+            '--insecure', metavar='HASH-ALGORITHM', choices=['md5', 'sha1'],
             help="""WARNING: MD5 and SHA1 are insecure hash algorithms; they \
             should only be used to check for unintentional data corruption. If \
             your options are limited to MD5 and/or SHA1, you can force \


### PR DESCRIPTION
Add's ability to identify SHA function used based on length of provided digest.  User can also specify to use SHA-3 over default option of SHA-2.  BLAKE and SHAKE were originally part of this merge, but I wasn't satisfied with their implementation so all features related to those two hash algorithms were removed.  