### PR TITLE
Feature/auto line break

### DIFF
--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -11,92 +11,117 @@ if sys.version_info < (3, 6):
 # -----------------------------------------------------------------------------
 
 import os
-import hmac  # Python 2.7 and 3.3+
+import hmac
 
+"""Classes and functions for creating and comparing hash digests
 
-# TODO: Implement SHAKE and BLAKE
-# TODO: Resist urge to call it "SHAKE'N BLAKE"
-# TODO: Allow user to pass get_hash_method string of hashlib hexdigest call
+Todo:
+    * Implement SHAKE and BLAKE
+    * Resist urge to call it "SHAKE'N BLAKE"
+    * Allow user to pass get_hash_method string of hashlib hexdigest call
+"""
+
 
 class Digest(object):
-    """Class for comparing, processing, and generating hash digests."""
+    """Class for comparing, processing, and generating hash digests.
 
-    def __init__(self, hash_family):
+    Attributes:
+        hash_family (str): Designates which hash family/version will be used to
+            generate a digest from a binary.
+        reference_digest (str, optional):  Digest used to deduce SHA2/SHA3 bit
+            length-e.g., SHA224 vs SHA226. This is primarily used for comparing a
+            master digest of a binary against a local copy.
+    """
+
+    def __init__(self, hash_family, reference_digest=None):
         self.hash_family = hash_family
-
-    def get_hash_method(self, sha_digest=None):
-        """Returns SHA method to be used for digest comparison
-
-        Args:
-            sha_digest (str): user provided hex-digest used to determine SHA method
-
-        Returns:
-            str: exact name of built in hashlib method as a string
-        """
-
-        hash_methods = {
-            'sha2': {56: 'sha224', 64: 'sha256', 96: 'sha384', 128: 'sha512'},
-            'sha3': {56: 'sha3_224', 64: 'sha3_256', 96: 'sha3_384', 128: 'sha3_512'}
-        }
-
-        insecure_methods = ['md5', 'sha1']
-
-        if self.hash_family not in insecure_methods:
-            return hash_methods[self.hash_family][len(sha_digest)]
-        else:
-            return self.hash_family
+        if reference_digest:
+            self.reference_digest = self.process_digest(reference_digest)
 
     @staticmethod
-    def process_digest(digest):
+    def process_digest(source):
         """Determines if source of digest is stored in a text file, or if it's a
         string provided by user.
 
         Args:
-            digest (str): filename or string containing digest to be processed
+            source (str): Filename or string containing source to be processed.
 
         Returns:
-            str: hash digest stripped of leading and trailing whitespace
+            str: Hash source digest stripped of leading and trailing whitespace.
         """
 
-        if os.path.isfile(digest):
-            with open(digest, 'r') as f:
+        if os.path.isfile(source):
+            with open(source, 'r') as f:
                 return f.read().split(' ')[0]
         else:
-            return digest.strip()
+            return source.strip()
 
     def generate_digest(self, filename):
         """Returns hexadecimal digest generated from filename
 
         Args:
-            filename (str): filename of binary file
+            filename (str): Filename of binary file.
 
         Returns:
-            str: hash digest generated from binary file
+            str: Hash digest generated from binary file.
         """
 
         buffer_size = 65536  # Buffer used to cut down on memory for large files.
         blocks = (os.path.getsize(filename) // buffer_size) + 1
 
-        hash_object = getattr(hashlib, self.get_hash_method())()
+        hash_digest = getattr(hashlib, self.get_hash_method())()
 
         with open(filename, 'rb') as f:
             # generator expression used for reading file in chunks
             generator = (f.read(buffer_size) for _ in range(blocks))
             for data in generator:
-                hash_object.update(data)
+                hash_digest.update(data)
 
-        return hash_object.hexdigest()
+        return hash_digest.hexdigest()
 
+    def get_hash_method(self):
+        """Returns method to be used for digest comparison
+
+        Args:
+            sha_digest (str, optional): SHA2/SHA3 digest to be dispatched
+                against sha_methods dictionary.
+
+        Returns:
+            str: Exact name of built-in hashlib method as a string.
+        """
+
+        # Method can be deduced by digest length if SHA2/SHA3 digest provided
+        sha_methods = {
+            'sha2': {56: 'sha224', 64: 'sha256', 96: 'sha384', 128: 'sha512'},
+            'sha3': {56: 'sha3_224', 64: 'sha3_256', 96: 'sha3_384', 128: 'sha3_512'}
+        }
+
+        if self.reference_digest and (self.hash_family in sha_methods):
+            family = sha_methods[self.hash_family]
+            reference_length = len(self.reference_digest)
+            try:
+                return family[reference_length]
+            except KeyError:
+                """If the reference digest length doesn't match any standard SHA
+                digest output length, the 'closest' value is returned.  This
+                will result in a comparison fail, but output formatting will
+                show the length difference"""
+
+                deviations = [(abs(x-reference_length), x) for x in family.keys()]
+                return family[min(deviations)[1]]
+
+        elif self.hash_family in ['md5', 'sha1']:
+            return self.hash_family
 
 def compare_digests(digest_1, digest_2):
-    """Returns result of equality comparison between digest_1 and digest_2.  Included
+    """Returns result of equality comparison between digest_1 and digest_2.
 
     Args:
-        digest_1 (str): digest to be compared against digest_2
-        digest_2 (str): digest to be compared against digest_1
+        digest_1 (str): Digest to be compared against digest_2.
+        digest_2 (str): Digest to be compared against digest_1.
 
     Returns:
-        bool: result of comparison of digest_1 and digest_2
+        bool: Result of comparison of digest_1 and digest_2.
     """
 
     return hmac.compare_digest(digest_1, digest_2)

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -1,3 +1,11 @@
+"""Classes and functions for creating and comparing hash digests
+
+Todo:
+    * Implement SHAKE and BLAKE
+    * Resist urge to call it "SHAKE'N BLAKE"
+    * Allow user to pass get_hash_method string of hashlib hexdigest call
+"""
+
 # ----------------------------Compatibility Imports----------------------------
 from __future__ import print_function
 from six.moves import range
@@ -12,14 +20,6 @@ if sys.version_info < (3, 6):
 
 import os
 import hmac
-
-"""Classes and functions for creating and comparing hash digests
-
-Todo:
-    * Implement SHAKE and BLAKE
-    * Resist urge to call it "SHAKE'N BLAKE"
-    * Allow user to pass get_hash_method string of hashlib hexdigest call
-"""
 
 
 class Digest(object):
@@ -66,7 +66,7 @@ class Digest(object):
             str: Hash digest generated from binary file.
         """
 
-        buffer_size = 65536  # Buffer used to cut down on memory for large files.
+        buffer_size = 65536  # buffer used to cut down on memory for large files
         blocks = (os.path.getsize(filename) // buffer_size) + 1
 
         hash_digest = getattr(hashlib, self.get_hash_method())()
@@ -94,16 +94,15 @@ class Digest(object):
 
         if self.reference_digest and (self.hash_family in sha_methods):
             family = sha_methods[self.hash_family]
-            reference_length = len(self.reference_digest)
+            digest_length = len(self.reference_digest)
             try:
-                return family[reference_length]
+                return family[digest_length]
             except KeyError:
-                """If the reference digest length doesn't match any standard SHA
-                digest output length, the 'closest' value is returned.  This
-                will result in a comparison fail, but output formatting will
-                show the length difference"""
+                """KeyError results from incorrect digest entry.  If this
+                happens, the 'closest' sha-method is returned.  Printout of the
+                comparison results will highlight this error."""
 
-                deviations = [(abs(x - reference_length), x) for x in family.keys()]
+                deviations = [(abs(x - digest_length), x) for x in family]
                 return family[min(deviations)[1]]
 
         elif self.hash_family in ['md5', 'sha1']:
@@ -111,11 +110,8 @@ class Digest(object):
 
 
 def compare_digests(digest_1, digest_2):
-    """Returns result of equality comparison between digest_1 and digest_2.
-
-    Args:
-        digest_1 (str): Digest to be compared against digest_2.
-        digest_2 (str): Digest to be compared against digest_1.
+    """Returns result of equality comparison between strings digest_1 and
+    digest_2.
 
     Returns:
         bool: Result of comparison of digest_1 and digest_2.

--- a/src/hash_check/hashchk.py
+++ b/src/hash_check/hashchk.py
@@ -82,10 +82,6 @@ class Digest(object):
     def get_hash_method(self):
         """Returns method to be used for digest comparison
 
-        Args:
-            sha_digest (str, optional): SHA2/SHA3 digest to be dispatched
-                against sha_methods dictionary.
-
         Returns:
             str: Exact name of built-in hashlib method as a string.
         """
@@ -107,11 +103,12 @@ class Digest(object):
                 will result in a comparison fail, but output formatting will
                 show the length difference"""
 
-                deviations = [(abs(x-reference_length), x) for x in family.keys()]
+                deviations = [(abs(x - reference_length), x) for x in family.keys()]
                 return family[min(deviations)[1]]
 
         elif self.hash_family in ['md5', 'sha1']:
             return self.hash_family
+
 
 def compare_digests(digest_1, digest_2):
     """Returns result of equality comparison between digest_1 and digest_2.

--- a/src/hash_check/hashchk_terminal.py
+++ b/src/hash_check/hashchk_terminal.py
@@ -6,12 +6,13 @@ import argparse
 import colorama
 import hashchk
 
-"""Classes and functions for hashchk terminal use"""
+"""Classes and functions for hashchk.py terminal use
 
+Todo:
+    * Re-implement SHAKE and BLAKE arguments
+    * More tests on what arguments common argument groups return
 
-# TODO: Re-implement shake and blake
-# TODO: More tests on what arguments common argument groups return
-
+"""
 
 class HashChkParser(object):
     """Class for creating and assembling argparse object used in hashchk.py"""
@@ -66,7 +67,7 @@ class HashChkParser(object):
             on the length of the provided digest.""")
 
         algorithms_group.add_argument(
-            '--insecure', metavar='NAME', dest='hash_family', choices=['md5', 'sha1'],
+            '--insecure', metavar='md5|sha1', dest='hash_family', choices=['md5', 'sha1'],
             help="""WARNING: MD5 and SHA1 are insecure hash algorithms; they \
             should only be used to check for unintentional data corruption. \
             You can force use of one of these two methods by using this switch \
@@ -93,14 +94,17 @@ class Output(object):
     def print_comparison_results(comparison_result):
         """Prints out results of comparison between two hash digests"""
 
+        GREEN, RED = colorama.Fore.GREEN, colorama.Fore.RED
+        BRIGHT, RESET = colorama.Style.BRIGHT, colorama.Style.RESET_ALL
+
         if comparison_result:
-            print("\n {}{}SUCCESS: Digests Match{}{}\n".format(
-                "---------------------------", colorama.Fore.GREEN,
-                colorama.Style.RESET_ALL, "----------------------------"))
+            print("\n {}{}{}SUCCESS: Digests Match{}{}\n".format(
+                "---------------------------", BRIGHT, GREEN,
+                RESET, "----------------------------"))
         else:
-            print("\n {}{}FAIL: Digests DO NOT Match{}{}\n".format(
-                "************************", colorama.Fore.RED,
-                colorama.Style.RESET_ALL, "*************************"))
+            print("\n {}{}{}FAIL: Digests DO NOT Match{}{}\n".format(
+                "************************", BRIGHT, RED,
+                RESET, "*************************"))
 
 
 def _compare_verify_digests(verify_args):
@@ -108,10 +112,11 @@ def _compare_verify_digests(verify_args):
     out comparison results."""
 
     Output.print_comparison_startup()
-    digest = hashchk.Digest(hash_family=verify_args.hash_family)
+    digest = hashchk.Digest(
+        hash_family=verify_args.hash_family, reference_digest=verify_args.digest)
 
     # provided printout
-    provided_digest = digest.process_digest(verify_args.digest)
+    provided_digest = digest.reference_digest
     print(" Provided :{}".format(provided_digest))
 
     # stdout used to provide status message while digest is being generated
@@ -127,5 +132,6 @@ def _compare_verify_digests(verify_args):
 if __name__ == '__main__':
     os.system('cls')
     colorama.init(convert=True)
+
     args = HashChkParser().get_parser_args()
     _compare_verify_digests(args)

--- a/src/hash_check/hashchk_terminal.py
+++ b/src/hash_check/hashchk_terminal.py
@@ -1,25 +1,32 @@
-from __future__ import print_function
-
-import os
-import sys
-import argparse
-import colorama
-import difflib
-import hashchk
-
 """Classes and functions for hashchk.py terminal use
 
 Todo:
+    * Finish adding doc strings
     * Re-implement SHAKE and BLAKE arguments
     * More tests on what arguments common argument groups return
 
 """
+from __future__ import print_function
+import os
+import sys
+import argparse
+import difflib
+
+from colorama import (Fore, Style, init)
+import hashchk
 
 
 class HashChkParser(object):
-    """Class for creating and assembling argparse object used in hashchk.py"""
+    """Class for creating and assembling argparse object used in hashchk.py
+
+    Attributes:
+        parser (obj): Top-level argparse object
+        subparser (obj): Parent subparser object
+    """
 
     def __init__(self):
+        """Summary
+        """
         self.parser = self.create_parser()
         self.subparser = self.create_subparser()
 
@@ -27,24 +34,25 @@ class HashChkParser(object):
 
     @staticmethod
     def create_parser():
-        """Returns main parser object used for all argparse arguments"""
+        """Creates and returns main parser object used for all argparse
+        arguments."""
 
         return argparse.ArgumentParser(
             description="Generate and compare hash digests")
 
     def create_subparser(self):
-        """returns main subparser derived from self.parser"""
+        """Creates and returns main subparser derived from self.parser."""
 
         return self.parser.add_subparsers(
             title="Commands", description="Available Actions")
 
     def add_verify_subparser(self):
-        """Creates the 'verify' subparser and adds related arguments"""
+        """Creates the 'verify' subparser and adds related arguments."""
 
         verify_parser = self.subparser.add_parser(
             'verify',
-            help="""Generate a hash digest from a binary and compare it against \
-            a provided digest using SHA-2 (default) or SHA-3""")
+            help="""Generate a hash digest from a binary and compare it \
+            against a provided digest using SHA-2 (default) or SHA-3""")
 
         # Required parameters group
         req_group = verify_parser.add_argument_group('Required Parameters')
@@ -59,7 +67,7 @@ class HashChkParser(object):
             help="""Generates a hash digest of of the file located at \
             PATH/FILENAME, or just FILENAME if file is located in the cwd.""")
 
-        # Algorithm choices
+        # Algorithm choices group
         algorithms_group = verify_parser.add_argument_group('Algorithm Parameters')
         algorithms_group.add_argument(
             '-sha3', dest='hash_family', action='store_const', const='sha3',
@@ -69,34 +77,40 @@ class HashChkParser(object):
             on the length of the provided digest.""")
 
         algorithms_group.add_argument(
-            '--insecure', metavar='md5|sha1', dest='hash_family', choices=['md5', 'sha1'],
+            '--insecure',
+            metavar='md5|sha1', dest='hash_family', choices=['md5', 'sha1'],
             help="""WARNING: MD5 and SHA1 are insecure hash algorithms; they \
             should only be used to check for unintentional data corruption. \
             You can force use of one of these two methods by using this switch \
             along with the hash algorithm name.""")
 
-        # Output choices
+        # Output choices group
         output_group = verify_parser.add_argument_group('Output Options')
         output_group.add_argument(
             '-diff', dest='diff', action='store_true',
             help="Print differences (if any) between digests")
 
-
     def get_parser_args(self):
-        """Returns arguments parsed by main argparse object"""
+        """Returns arguments parsed by main argparse object
+
+        Returns:
+            obj: Namespace containing all arguments parsed through terminal
+
+        """
 
         return self.parser.parse_args()
 
 
 class Output(object):
-    """Organizational class for reusable printout messages"""
-    C = colorama
-    GREEN, RED, CYAN = C.Fore.GREEN, C.Fore.RED, C.Fore.CYAN
-    BRIGHT, RESET = C.Style.BRIGHT, C.Style.RESET_ALL
+    """Organizational class for reusable printout messages."""
+
+    GREEN, RED, CYAN = Fore.GREEN, Fore.RED, Fore.CYAN
+    BRIGHT, RESET = Style.BRIGHT, Style.RESET_ALL
 
     @staticmethod
     def print_comparison_startup():
-        """Prints out startup message for comparison process"""
+        """Prints out startup message for comparison process
+        """
 
         print("\n {}Comparing Now{}\n".format(
             "--------------------------------",
@@ -104,7 +118,11 @@ class Output(object):
 
     @classmethod
     def print_comparison_results(cls, comparison_result):
-        """Prints out results of comparison between two hash digests"""
+        """Prints out results of comparison between two hash digests
+
+        Args:
+            comparison_result (bool): Result of digest comparison
+        """
 
         if comparison_result:
             print("\n {}{}{}SUCCESS: Digests Match{}{}\n".format(
@@ -116,31 +134,43 @@ class Output(object):
                 cls.RESET, "*************************"))
 
     @staticmethod
-    def print_diffs(digest_1, digest_2, tags=None):
-        diffs = list(difflib.ndiff([digest_1], [digest_2]))
-        diffs = [line.replace('\n', '') for line in diffs]
-        titles = tags or ['Digest1', 'Digest2']
+    def print_diffs(digest_1, digest_2, identifiers=None):
+        """Summary
 
+        Args:
+            digest_1 (str): 1 of 2 digests used for diff comparison
+            digest_2 (str): 2 of 2 digests used for diff comparison
+            identifiers (list[str], optional): Prefix titles to distinguish
+                digests apart
+        """
+
+        diffs = list(difflib.Differ().compare([digest_1+'\n'], [digest_2+'\n']))
+        titles = identifiers or ['Digest1', 'Digest2']
 
         print("\n{}Diffs{}\n".format(
             "------------------------------------",
             "------------------------------------"))
 
         padding = max(len(title) for title in titles)
-        for index, diff in enumerate(diffs):
+        for index, line in enumerate(diffs):
             if index in [0, 2]:
-                print("{:{pad}}: {}".format(titles.pop(0), diff, pad=padding))
+                sys.stdout.write("{:{p}}: {}".format(
+                    titles.pop(0), line, p=padding))
             else:
-                print("{:{pad}}  {}".format(" ", diff, pad=padding))
+                sys.stdout.write("{:{p}}  {}".format(" ", line, p=padding))
 
-        print("\n{}End{}\n".format(
+        print("{}End{}\n".format(
             "-------------------------------------",
             "-------------------------------------"))
 
 
 def _compare_verify_digests(verify_args):
     """Takes in parsed arguments from HashChkParser verify subparser and prints
-    out comparison results."""
+    out comparison results.
+
+    Args:
+        verify_args (:obo:`Namespace`): All arguments parsed from HashChkParser
+    """
 
     Output.print_comparison_startup()
     digest = hashchk.Digest(
@@ -166,7 +196,7 @@ def _compare_verify_digests(verify_args):
 
 if __name__ == '__main__':
     os.system('cls')
-    colorama.init(convert=True)
+    init(convert=True)  # colorama module
 
     args = HashChkParser().get_parser_args()
     _compare_verify_digests(args)


### PR DESCRIPTION
`Output()` changed to `Terminal()` to reflect method changes and restructuring.  `Terminal()` now acts like a standard class instead of a method of holding semi-related functions. Importantly, `Terminal()` dynamically generates printout messages based on the length of the digests given to hashchk as a whole. 

Visual line breaks are now all generated automatically based on the length of the centered comment tag via Terminal.build_line_breaks(). This removed the numerous long print statements containing hard coded visual line breaks.  